### PR TITLE
FK-29 Incident 생성 (Create) API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+
+/mysql/

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "4"
+services:
+  mysql:
+    image: mysql:8.3.0
+    container_name: mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: mysql
+      MYSQL_DATABASE: service_desk
+    ports:
+      - "3306:3306"
+    volumes:
+      - ./mysql:/var/lib/mysql
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,12 @@ version: "4"
 services:
   mysql:
     image: mysql:8.3.0
-    container_name: mysql
+    container_name: mysql_user
     environment:
-      MYSQL_ROOT_PASSWORD: mysql
-      MYSQL_DATABASE: service_desk
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
     ports:
-      - "3306:3306"
+      - "${MYSQL_PORT}:3306"
     volumes:
       - ./mysql:/var/lib/mysql
 

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/ServiceDeskApplication.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/ServiceDeskApplication.java
@@ -13,5 +13,4 @@ public class ServiceDeskApplication {
     public static void main(String[] args) {
         SpringApplication.run(ServiceDeskApplication.class, args);
     }
-
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/ServiceDeskApplication.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/ServiceDeskApplication.java
@@ -2,7 +2,12 @@ package com.capston_design.fkiller.itoms.service_desk;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+
+@EnableScheduling
+@EnableJpaAuditing
 @SpringBootApplication
 public class ServiceDeskApplication {
     public static void main(String[] args) {

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/apiPayload/ApiResponse.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/apiPayload/ApiResponse.java
@@ -1,0 +1,32 @@
+package com.capston_design.fkiller.itoms.service_desk.apiPayload;
+
+import com.capston_design.fkiller.itoms.service_desk.apiPayload.code.status.SuccessStatus;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class ApiResponse<T> {
+
+    @JsonProperty("isSuccess")
+    private final Boolean isSuccess;
+    private final String code;
+    private final String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T result;
+
+
+    // 성공한 경우 응답 생성
+    public static <T> ApiResponse<T> onSuccess(T result){
+        return new ApiResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), result);
+    }
+
+    // 실패한 경우 응답 생성
+    public static <T> ApiResponse<T> onFailure(String code, String message, T data){
+        return new ApiResponse<>(false, code, message, data);
+    }
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/apiPayload/code/BaseCode.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/apiPayload/code/BaseCode.java
@@ -1,0 +1,8 @@
+package com.capston_design.fkiller.itoms.service_desk.apiPayload.code;
+
+public interface BaseCode {
+
+    public ReasonDTO getReason();
+
+    public ReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/apiPayload/code/BaseErrorCode.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/apiPayload/code/BaseErrorCode.java
@@ -1,0 +1,8 @@
+package com.capston_design.fkiller.itoms.service_desk.apiPayload.code;
+
+public interface BaseErrorCode {
+
+    public ErrorReasonDTO getReason();
+
+    public ErrorReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/apiPayload/code/ErrorReasonDTO.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/apiPayload/code/ErrorReasonDTO.java
@@ -1,0 +1,18 @@
+package com.capston_design.fkiller.itoms.service_desk.apiPayload.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ErrorReasonDTO {
+
+    private HttpStatus httpStatus;
+
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    public boolean getIsSuccess(){return isSuccess;}
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/apiPayload/code/ReasonDTO.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/apiPayload/code/ReasonDTO.java
@@ -1,0 +1,18 @@
+package com.capston_design.fkiller.itoms.service_desk.apiPayload.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ReasonDTO {
+
+    private HttpStatus httpStatus;
+
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    public boolean getIsSuccess(){return isSuccess;}
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/apiPayload/code/status/ErrorStatus.java
@@ -1,0 +1,49 @@
+package com.capston_design.fkiller.itoms.service_desk.apiPayload.code.status;
+
+import com.capston_design.fkiller.itoms.service_desk.apiPayload.code.BaseErrorCode;
+import com.capston_design.fkiller.itoms.service_desk.apiPayload.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseErrorCode {
+
+    // 가장 일반적인 응답
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+
+    // 멤버 관려 에러
+    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다."),
+
+    // Ror test
+    TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "이거는 테스트");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build()
+                ;
+    }
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/apiPayload/code/status/SuccessStatus.java
@@ -1,0 +1,43 @@
+package com.capston_design.fkiller.itoms.service_desk.apiPayload.code.status;
+
+import com.capston_design.fkiller.itoms.service_desk.apiPayload.code.BaseCode;
+import com.capston_design.fkiller.itoms.service_desk.apiPayload.code.ReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseCode {
+
+    // 일반적인 응답
+    _OK(HttpStatus.OK, "COMMON200", "성공입니다.");
+
+    // 멤버 관련 응답
+
+    // ~~~ 관련 응답
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReason() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .build();
+    }
+
+    @Override
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .httpStatus(httpStatus)
+                .build()
+                ;
+    }
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/apiPayload/exception/ExceptionAdvice.java
@@ -1,0 +1,119 @@
+package com.capston_design.fkiller.itoms.service_desk.apiPayload.exception;
+
+import com.capston_design.fkiller.itoms.service_desk.apiPayload.ApiResponse;
+import com.capston_design.fkiller.itoms.service_desk.apiPayload.code.ErrorReasonDTO;
+import com.capston_design.fkiller.itoms.service_desk.apiPayload.code.status.ErrorStatus;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@RestControllerAdvice(annotations = {RestController.class})
+public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+
+    @ExceptionHandler
+    public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
+        String errorMessage = e.getConstraintViolations().stream()
+                .map(constraintViolation -> constraintViolation.getMessage())
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("ConstraintViolationException 추출 도중 에러 발생"));
+
+        return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY,request);
+    }
+
+    @Override
+    public ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+        Map<String, String> errors = new LinkedHashMap<>();
+
+        e.getBindingResult().getFieldErrors().stream()
+                .forEach(fieldError -> {
+                    String fieldName = fieldError.getField();
+                    String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+                    errors.merge(fieldName, errorMessage, (existingErrorMessage, newErrorMessage) -> existingErrorMessage + ", " + newErrorMessage);
+                });
+
+        return handleExceptionInternalArgs(e,HttpHeaders.EMPTY,ErrorStatus.valueOf("_BAD_REQUEST"),request,errors);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+        e.printStackTrace();
+
+        return handleExceptionInternalFalse(e, ErrorStatus._INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY, ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus(),request, e.getMessage());
+    }
+
+    @ExceptionHandler(value = GeneralException.class)
+    public ResponseEntity onThrowException(GeneralException generalException, HttpServletRequest request) {
+        ErrorReasonDTO errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+        return handleExceptionInternal(generalException,errorReasonHttpStatus,null,request);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorReasonDTO reason,
+                                                           HttpHeaders headers, HttpServletRequest request) {
+
+        ApiResponse<Object> body = ApiResponse.onFailure(reason.getCode(),reason.getMessage(),null);
+//        e.printStackTrace();
+
+        WebRequest webRequest = new ServletWebRequest(request);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                reason.getHttpStatus(),
+                webRequest
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalFalse(Exception e, ErrorStatus errorCommonStatus,
+                                                                HttpHeaders headers, HttpStatus status, WebRequest request, String errorPoint) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorPoint);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                status,
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalArgs(Exception e, HttpHeaders headers, ErrorStatus errorCommonStatus,
+                                                               WebRequest request, Map<String, String> errorArgs) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorArgs);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalConstraint(Exception e, ErrorStatus errorCommonStatus,
+                                                                     HttpHeaders headers, WebRequest request) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(), null);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/apiPayload/exception/GeneralException.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/apiPayload/exception/GeneralException.java
@@ -1,0 +1,21 @@
+package com.capston_design.fkiller.itoms.service_desk.apiPayload.exception;
+
+import com.capston_design.fkiller.itoms.service_desk.apiPayload.code.BaseErrorCode;
+import com.capston_design.fkiller.itoms.service_desk.apiPayload.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException {
+
+    private BaseErrorCode code;
+
+    public ErrorReasonDTO getErrorReason() {
+        return this.code.getReason();
+    }
+
+    public ErrorReasonDTO getErrorReasonHttpStatus(){
+        return this.code.getReasonHttpStatus();
+    }
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/controller/IncidentController.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/controller/IncidentController.java
@@ -1,0 +1,21 @@
+package com.capston_design.fkiller.itoms.service_desk.controller;
+
+import com.capston_design.fkiller.itoms.service_desk.dto.IncidentRequest;
+import com.capston_design.fkiller.itoms.service_desk.service.IncidentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/incident")
+@RequiredArgsConstructor
+public class IncidentController {
+    private final IncidentService incidentService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public String createIncident(@RequestBody IncidentRequest incidentRequest) {
+        incidentService.createIncident(incidentRequest);
+        return "Incident created";
+    }
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/controller/IncidentController.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/controller/IncidentController.java
@@ -1,9 +1,14 @@
 package com.capston_design.fkiller.itoms.service_desk.controller;
 
+import com.capston_design.fkiller.itoms.service_desk.apiPayload.ApiResponse;
+import com.capston_design.fkiller.itoms.service_desk.converter.IncidentConverter;
 import com.capston_design.fkiller.itoms.service_desk.dto.IncidentRequest;
+import com.capston_design.fkiller.itoms.service_desk.dto.IncidentResponse;
+import com.capston_design.fkiller.itoms.service_desk.model.Incident;
 import com.capston_design.fkiller.itoms.service_desk.service.IncidentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -13,9 +18,11 @@ public class IncidentController {
     private final IncidentService incidentService;
 
     @PostMapping
-    @ResponseStatus(HttpStatus.CREATED)
-    public String createIncident(@RequestBody IncidentRequest incidentRequest) {
-        incidentService.createIncident(incidentRequest);
-        return "Incident created";
+    public ResponseEntity<ApiResponse<IncidentResponse.IncidentCreateResponseDTO>> createIncident(
+            @RequestBody IncidentRequest incidentRequest) {
+
+        Incident incident = incidentService.createIncident(incidentRequest);
+        var responseDTO = IncidentConverter.toIncidentResponseDTO(incident);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.onSuccess(responseDTO));
     }
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/converter/IncidentConverter.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/converter/IncidentConverter.java
@@ -14,6 +14,7 @@ public class IncidentConverter {
                 .acceptDT(incident.getAcceptDT())
                 .endDT(incident.getEndDT())
                 .status(incident.getStatus())
+                .priority(incident.getPriority())
                 .createrById(incident.getCreaterById())
                 .chargerById(incident.getChargerById())
                 .creater(incident.getCreater())

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/converter/IncidentConverter.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/converter/IncidentConverter.java
@@ -1,0 +1,23 @@
+package com.capston_design.fkiller.itoms.service_desk.converter;
+
+import com.capston_design.fkiller.itoms.service_desk.dto.IncidentResponse;
+import com.capston_design.fkiller.itoms.service_desk.model.Incident;
+
+public class IncidentConverter {
+
+    public static IncidentResponse.IncidentCreateResponseDTO toIncidentResponseDTO(Incident incident) {
+        return IncidentResponse.IncidentCreateResponseDTO.builder()
+                .id(incident.getId())
+                .title(incident.getTitle())
+                .content(incident.getContent())
+                .requestDT(incident.getRequestDT())
+                .acceptDT(incident.getAcceptDT())
+                .endDT(incident.getEndDT())
+                .status(incident.getStatus())
+                .createrById(incident.getCreaterById())
+                .chargerById(incident.getChargerById())
+                .creater(incident.getCreater())
+                .charger(incident.getCharger())
+                .build();
+    }
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/dto/IncidentRequest.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/dto/IncidentRequest.java
@@ -1,0 +1,8 @@
+package com.capston_design.fkiller.itoms.service_desk.dto;
+
+import java.time.LocalDateTime;
+
+public record IncidentRequest(
+        String title,
+        String content
+) {}

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/dto/IncidentRequest.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/dto/IncidentRequest.java
@@ -4,5 +4,6 @@ import java.time.LocalDateTime;
 
 public record IncidentRequest(
         String title,
-        String content
+        String content,
+        String priority
 ) {}

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/dto/IncidentResponse.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/dto/IncidentResponse.java
@@ -1,0 +1,21 @@
+package com.capston_design.fkiller.itoms.service_desk.dto;
+
+import com.capston_design.fkiller.itoms.service_desk.model.enums.Status;
+
+import java.time.LocalDateTime;
+
+public record IncidentResponse(
+        Long id,
+        String title,
+        String content,
+        LocalDateTime requestDT,
+        LocalDateTime acceptDT,
+        LocalDateTime endDT,
+        Status status,
+        String createrById,
+        String chargerById,
+        String creater,
+        String charger,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {}

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/dto/IncidentResponse.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/dto/IncidentResponse.java
@@ -1,6 +1,8 @@
 package com.capston_design.fkiller.itoms.service_desk.dto;
 
+import com.capston_design.fkiller.itoms.service_desk.model.enums.Priority;
 import com.capston_design.fkiller.itoms.service_desk.model.enums.Status;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import lombok.AllArgsConstructor;
@@ -9,6 +11,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 public class IncidentResponse {
 
@@ -17,16 +20,23 @@ public class IncidentResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class IncidentCreateResponseDTO{
-        private Long id;
+        private UUID id;
         private String title;
         private String content;
         private LocalDateTime requestDT;
         private LocalDateTime acceptDT;
         private LocalDateTime endDT;
         private Status status;
-        private Long createrById;
-        private Long chargerById;
+        private Priority priority;
+        private UUID createrById;
+        private UUID chargerById;
         private String creater;
         private String charger;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+        private LocalDateTime createdAt;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+        private LocalDateTime updatedAt;
     }
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/dto/IncidentResponse.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/dto/IncidentResponse.java
@@ -1,21 +1,32 @@
 package com.capston_design.fkiller.itoms.service_desk.dto;
 
 import com.capston_design.fkiller.itoms.service_desk.model.enums.Status;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-public record IncidentResponse(
-        Long id,
-        String title,
-        String content,
-        LocalDateTime requestDT,
-        LocalDateTime acceptDT,
-        LocalDateTime endDT,
-        Status status,
-        String createrById,
-        String chargerById,
-        String creater,
-        String charger,
-        LocalDateTime createdAt,
-        LocalDateTime updatedAt
-) {}
+public class IncidentResponse {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class IncidentCreateResponseDTO{
+        private Long id;
+        private String title;
+        private String content;
+        private LocalDateTime requestDT;
+        private LocalDateTime acceptDT;
+        private LocalDateTime endDT;
+        private Status status;
+        private Long createrById;
+        private Long chargerById;
+        private String creater;
+        private String charger;
+    }
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/model/Incident.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/model/Incident.java
@@ -1,0 +1,40 @@
+package com.capston_design.fkiller.itoms.service_desk.model;
+
+import com.capston_design.fkiller.itoms.service_desk.model.common.BaseEntity;
+import com.capston_design.fkiller.itoms.service_desk.model.enums.Status;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name= "t_incident")
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Incident extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+    private String content;
+
+    private LocalDateTime requestDT;
+    private LocalDateTime acceptDT;
+    private LocalDateTime endDT;
+
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    private Long createrById;
+    private Long chargerById;
+
+    private String creater;
+    private String charger;
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/model/Incident.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/model/Incident.java
@@ -1,14 +1,17 @@
 package com.capston_design.fkiller.itoms.service_desk.model;
 
 import com.capston_design.fkiller.itoms.service_desk.model.common.BaseEntity;
+import com.capston_design.fkiller.itoms.service_desk.model.enums.Priority;
 import com.capston_design.fkiller.itoms.service_desk.model.enums.Status;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.GenericGenerator;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Entity
 @Table(name= "t_incident")
@@ -19,8 +22,10 @@ import java.time.LocalDateTime;
 public class Incident extends BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @GeneratedValue(generator = "UUID")
+    @GenericGenerator(name = "UUID", strategy = "org.hibernate.id.UUIDGenerator")
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
 
     private String title;
     private String content;
@@ -32,8 +37,13 @@ public class Incident extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Status status;
 
-    private Long createrById;
-    private Long chargerById;
+    @Enumerated(EnumType.STRING)
+    private Priority priority;
+
+    private UUID ticketByID;
+
+    private UUID createrById;
+    private UUID chargerById;
 
     private String creater;
     private String charger;

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/model/common/BaseEntity.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/model/common/BaseEntity.java
@@ -1,0 +1,23 @@
+package com.capston_design.fkiller.itoms.service_desk.model.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}
+

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/model/enums/Priority.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/model/enums/Priority.java
@@ -2,10 +2,11 @@ package com.capston_design.fkiller.itoms.service_desk.model.enums;
 
 import java.util.Arrays;
 
-public enum Status {
-    Completed, Incomplete;
+public enum Priority {
+    URGENT,
+    RELAXED;
 
-    public static Status from(String value) {
+    public static Priority from(String value) {
         return Arrays.stream(values())
                 .filter(v -> v.name().equalsIgnoreCase(value))
                 .findFirst()

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/model/enums/Status.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/model/enums/Status.java
@@ -1,0 +1,5 @@
+package com.capston_design.fkiller.itoms.service_desk.model.enums;
+
+public enum Status {
+    Completed, Incomplete
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/repository/IncidentRepository.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/repository/IncidentRepository.java
@@ -1,0 +1,8 @@
+package com.capston_design.fkiller.itoms.service_desk.repository;
+
+import com.capston_design.fkiller.itoms.service_desk.model.Incident;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface IncidentRepository extends JpaRepository<Incident, Long> {
+
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/service/IncidentService.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/service/IncidentService.java
@@ -15,7 +15,7 @@ public class IncidentService {
 
     private final IncidentRepository incidentRepository;
 
-    public void createIncident(IncidentRequest incidentRequest) {
+    public Incident createIncident(IncidentRequest incidentRequest) {
 
         Incident incident = new Incident();
 
@@ -28,6 +28,6 @@ public class IncidentService {
         //String createrById = request.getHeader("X-User-Id");
         //String creater = request.getHeader("X-User-Name");
 
-        incidentRepository.save(incident);
+        return incidentRepository.save(incident);
     }
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/service/IncidentService.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/service/IncidentService.java
@@ -1,0 +1,33 @@
+package com.capston_design.fkiller.itoms.service_desk.service;
+
+import com.capston_design.fkiller.itoms.service_desk.dto.IncidentRequest;
+import com.capston_design.fkiller.itoms.service_desk.model.Incident;
+import com.capston_design.fkiller.itoms.service_desk.model.enums.Status;
+import com.capston_design.fkiller.itoms.service_desk.repository.IncidentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class IncidentService {
+
+    private final IncidentRepository incidentRepository;
+
+    public void createIncident(IncidentRequest incidentRequest) {
+
+        Incident incident = new Incident();
+
+        incident.setTitle(incidentRequest.title());
+        incident.setContent(incidentRequest.content());
+
+        incident.setRequestDT(LocalDateTime.now()); // 요청 시간
+        incident.setStatus(Status.Incomplete);      // 초기 상태
+
+        //String createrById = request.getHeader("X-User-Id");
+        //String creater = request.getHeader("X-User-Name");
+
+        incidentRepository.save(incident);
+    }
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/service/IncidentService.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/service/IncidentService.java
@@ -2,10 +2,12 @@ package com.capston_design.fkiller.itoms.service_desk.service;
 
 import com.capston_design.fkiller.itoms.service_desk.dto.IncidentRequest;
 import com.capston_design.fkiller.itoms.service_desk.model.Incident;
+import com.capston_design.fkiller.itoms.service_desk.model.enums.Priority;
 import com.capston_design.fkiller.itoms.service_desk.model.enums.Status;
 import com.capston_design.fkiller.itoms.service_desk.repository.IncidentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
@@ -15,6 +17,7 @@ public class IncidentService {
 
     private final IncidentRepository incidentRepository;
 
+    @Transactional
     public Incident createIncident(IncidentRequest incidentRequest) {
 
         Incident incident = new Incident();
@@ -24,7 +27,7 @@ public class IncidentService {
 
         incident.setRequestDT(LocalDateTime.now()); // 요청 시간
         incident.setStatus(Status.Incomplete);      // 초기 상태
-
+        incident.setPriority(Priority.from(incidentRequest.priority()));
         //String createrById = request.getHeader("X-User-Id");
         //String creater = request.getHeader("X-User-Name");
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,14 +1,14 @@
 spring:
   application:
-    name: ServiceDesk
+    name: user-service
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/service_desk
-    username: root
-    password: mysql
+    url: ${DB_URL}
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: ${DDL_ENV}
     open-in-view: true
     show-sql: true
     properties:
@@ -18,4 +18,4 @@ spring:
 
 springdoc:
   swagger-ui:
-    path: /swagger-ui.html
+    path: ${SWAGGER_PATH}/swagger-ui.html

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,21 @@
+spring:
+  application:
+    name: ServiceDesk
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/service_desk
+    username: root
+    password: mysql
+  jpa:
+    hibernate:
+      ddl-auto: create
+    open-in-view: true
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        default_batch_fetch_size: 100
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,21 @@
+spring:
+  application:
+    name: ServiceDesk
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DB_URL}
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: ${DDL_ENV}
+    open-in-view: true
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        default_batch_fetch_size: 100
+
+springdoc:
+  swagger-ui:
+    path: ${SWAGGER_PATH}/swagger-ui.html

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,20 +1,11 @@
 spring:
-  application:
-    name: ServiceDesk
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: ${DB_URL}
-    username: ${DB_USER}
-    password: ${DB_PASSWORD}
-  jpa:
-    hibernate:
-      ddl-auto: ${DDL_ENV}
-    open-in-view: true
-    show-sql: true
-    properties:
-      hibernate:
-        format_sql: true
-        default_batch_fetch_size: 100
-springdoc:
-  swagger-ui:
-    path: ${SWAGGER_PATH}/swagger-ui.html
+  # settings for profile
+  profiles:
+    active: local  # if you want to have the environment of the develop server, then it should be dev not local
+    include: secret
+  # settings for multipart data such as image
+
+  servlet:
+    multipart:
+      max-file-size: 10GB
+      max-request-size: 10GB


### PR DESCRIPTION
## 📝 PR 요약
문의사항 생성 (Create) API 구현

## 📌 관련 이슈
- Resolved: #1 

## 📂 변경 사항
- [x] Docker Compose로 MySQL 
  - [x] MySQL 8.3 이미지 정의
  - [x] 볼륨 설정 (./mysql 폴더)
- [x] Incident 생성 기능 구현
  - [x] IncidentService에  incident 생성 로직 구현
  - [x]  Incident 엔티티 정의
- [x] API 응답 통일 & 에러 헨들링
  - [x] 공통 ApiResponse로 응답 통일
  - [x] 예외 처리기(ExceptionAdvice) 구조 적용
  - [x] Converter 구성(IncidentConverter에 Entity → DTO 변환)

## ✅ PR 체크리스트
- [ ] docker compose로 mysql 띄우고 실행하시면 됩니다.
- [ ] 제목, 내용 입력 -> API응답(Incident의 정보가 result로)
- [ ] 반환할 때 작성한 사람과 담당자 배정은 아직 구현을 안해서 null로 해두었습니다. 

## 🤔 추가 논의 사항
실행 안되거나 맘에 안드는 코드 있으면 고칠게요
