### PR TITLE
FK-35 문의사항 생성시 사용자 할당

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "4"
 services:
   mysql:
     image: mysql:8.3.0
-    container_name: mysql_user
+    container_name: mysql_service_desk
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
       MYSQL_DATABASE: ${MYSQL_DATABASE}

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/client/UserClient.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/client/UserClient.java
@@ -1,0 +1,10 @@
+package com.capston_design.fkiller.itoms.service_desk.client;
+
+import com.capston_design.fkiller.itoms.service_desk.apiPayload.ApiResponse;
+import com.capston_design.fkiller.itoms.service_desk.dto.UserCreateResponseDTO;
+import org.springframework.web.service.annotation.GetExchange;
+
+public interface UserClient {
+    @GetExchange("/api/user/randomMember")
+    ApiResponse<UserCreateResponseDTO> getRandomMember();
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/client/UserClient.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/client/UserClient.java
@@ -6,5 +6,5 @@ import org.springframework.web.service.annotation.GetExchange;
 
 public interface UserClient {
     @GetExchange("/api/user/randomMember")
-    ApiResponse<UserCreateResponseDTO> getRandomMember();
+    ApiResponse<UserCreateResponseDTO> getRandomOutsourcedUser();
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/config/RestClientConfig.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/config/RestClientConfig.java
@@ -1,0 +1,27 @@
+package com.capston_design.fkiller.itoms.service_desk.config;
+
+
+import com.capston_design.fkiller.itoms.service_desk.client.UserClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.support.RestClientAdapter;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+
+@Configuration
+public class RestClientConfig {
+
+    @Value("${user.url}")
+    private String userServiceUrl;
+
+    @Bean
+    public UserClient userClient() {
+        RestClient restClient = RestClient.builder()
+                .baseUrl(userServiceUrl)
+                .build();
+        var adapter = RestClientAdapter.create(restClient);
+        var factory = HttpServiceProxyFactory.builderFor(adapter).build();
+        return factory.createClient(UserClient.class);
+    }
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/converter/IncidentConverter.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/converter/IncidentConverter.java
@@ -19,6 +19,8 @@ public class IncidentConverter {
                 .chargerById(incident.getChargerById())
                 .creater(incident.getCreater())
                 .charger(incident.getCharger())
+                .createdAt(incident.getCreatedAt())
+                .updatedAt(incident.getUpdatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/dto/UserCreateResponseDTO.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/dto/UserCreateResponseDTO.java
@@ -1,0 +1,19 @@
+package com.capston_design.fkiller.itoms.service_desk.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Setter
+@Builder
+public class UserCreateResponseDTO {
+    private UUID id;
+    private String name;
+    private String category;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/dto/UserCreateResponseDTO.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/dto/UserCreateResponseDTO.java
@@ -1,6 +1,7 @@
 package com.capston_design.fkiller.itoms.service_desk.dto;
 
-import lombok.Builder;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -9,11 +10,15 @@ import java.util.UUID;
 
 @Getter
 @Setter
-@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class UserCreateResponseDTO {
     private UUID id;
     private String name;
     private String category;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createdAt;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/model/Incident.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/model/Incident.java
@@ -14,18 +14,22 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
-@Table(name= "t_incident")
+@Table(name = "t_incident")
 @Getter
 @Setter
-@AllArgsConstructor
 @NoArgsConstructor
+@AllArgsConstructor
 public class Incident extends BaseEntity {
 
     @Id
-    @GeneratedValue(generator = "UUID")
-    @GenericGenerator(name = "UUID", strategy = "org.hibernate.id.UUIDGenerator")
-    @Column(name = "id", updatable = false, nullable = false)
     private UUID id;
+
+    @PrePersist
+    public void generateId() {
+        if (this.id == null) {
+            this.id = UUID.randomUUID();
+        }
+    }
 
     private String title;
     private String content;
@@ -41,10 +45,10 @@ public class Incident extends BaseEntity {
     private Priority priority;
 
     private UUID ticketByID;
-
     private UUID createrById;
     private UUID chargerById;
 
     private String creater;
     private String charger;
 }
+

--- a/src/main/java/com/capston_design/fkiller/itoms/service_desk/service/IncidentService.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_desk/service/IncidentService.java
@@ -1,6 +1,9 @@
 package com.capston_design.fkiller.itoms.service_desk.service;
 
+import com.capston_design.fkiller.itoms.service_desk.apiPayload.ApiResponse;
+import com.capston_design.fkiller.itoms.service_desk.client.UserClient;
 import com.capston_design.fkiller.itoms.service_desk.dto.IncidentRequest;
+import com.capston_design.fkiller.itoms.service_desk.dto.UserCreateResponseDTO;
 import com.capston_design.fkiller.itoms.service_desk.model.Incident;
 import com.capston_design.fkiller.itoms.service_desk.model.enums.Priority;
 import com.capston_design.fkiller.itoms.service_desk.model.enums.Status;
@@ -16,6 +19,7 @@ import java.time.LocalDateTime;
 public class IncidentService {
 
     private final IncidentRepository incidentRepository;
+    private final UserClient userClient;
 
     @Transactional
     public Incident createIncident(IncidentRequest incidentRequest) {
@@ -30,6 +34,16 @@ public class IncidentService {
         incident.setPriority(Priority.from(incidentRequest.priority()));
         //String createrById = request.getHeader("X-User-Id");
         //String creater = request.getHeader("X-User-Name");
+
+        ApiResponse<UserCreateResponseDTO> userResponse = userClient.getRandomOutsourcedUser();
+        if (userResponse == null || !Boolean.TRUE.equals(userResponse.getIsSuccess())
+                || userResponse.getResult() == null) {
+            throw new IllegalStateException("UserService로부터 랜덤 유저를 불러오지 못했습니다.");
+        }
+        UserCreateResponseDTO user = userResponse.getResult();
+
+        incident.setCharger(user.getName());
+        incident.setChargerById(user.getId());
 
         return incidentRepository.save(incident);
     }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,6 +1,6 @@
 spring:
   application:
-    name: user-service
+    name: ServiceDesk
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${DB_URL}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+user.url=http://localhost:8081


### PR DESCRIPTION
## 📝 PR 요약
Incident 생성시 User Category가 Outsourced 인 랜덤한 User의 id와 name을 charger와 chargedByID에 할당 

## 📌 관련 이슈
- Resolved: #3 

## 📂 변경 사항
- [x] RestClient를 사용해 다른 서비스와 통신하는 코드 추가
- [x] UserCreateResponseDTO 추가

## ✅ PR 체크리스트
- [ ] application 띄어 놓을데 port를 다르게
- [ ] 다른 서비스의 API를 사용할 때 반환하는 api의 DTO 형식이랑 일치하는 DTO를 만들어야 합니다. 

## 🤔 추가 논의 사항
ticket 생성하는거 이제 만들려 합니다.